### PR TITLE
Added ability to specify a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ $ sudo python setup.py install
 
 Get a token of slack webhook on [slack page](https://my.slack.com/services/new/incoming-webhook/).
 
-Instantiate:
+Instantiate, with optional proxy:
 <pre>
 > import slackweb
-> slack = slackweb.Slack(url="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX")
+> slack = slackweb.Slack(url="https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX", proxy="https://proxy.URI")
 </pre>
 
 In case that you want to send a simple message:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup_options = dict(
       "License :: OSI Approved :: MIT License"
     ]
 )
-setup_options["version"] = "1.0.5"
+setup_options["version"] = "1.1.0"
 setup_options.update(dict(
   packages         = ['slackweb'],
 ))

--- a/slackweb/slackweb.py
+++ b/slackweb/slackweb.py
@@ -15,9 +15,13 @@ import json
 
 class Slack():
 
-    def __init__(self, url=""):
+    def __init__(self, url="", proxy=None):
         self.url = url
-        self.opener = urlrequest.build_opener(urlrequest.HTTPHandler())
+        if proxy:
+                proxy = {'https': proxy}
+                self.opener = urlrequest.build_opener(urlrequest.HTTPHandler(), urlrequest.ProxyHandler(proxy))
+        else:
+                self.opener = urlrequest.build_opener(urlrequest.HTTPHandler())
 
     def notify(self, **kwargs):
         """


### PR DESCRIPTION
This PR adds the ability to specify a proxy for whenever it is impossible or impractical to specify the HTTP_PROXY envvar. I only set the https proxy, as the communication with Slack is over https. As I understand it, this means setting the http proxy is of no value.

Please let me know if there are any changes you'd like me to make for this to be included! My code is not always the most Pythonic and I'm always looking to learn more.